### PR TITLE
docs: update eas update limit in free pricing

### DIFF
--- a/app/projects/Hanmogm/page.tsx
+++ b/app/projects/Hanmogm/page.tsx
@@ -269,8 +269,7 @@ export default function HanmogmPage() {
           <Emphasize>코드만 푸시해도 업데이트가 되는 빌드를 구축</Emphasize>
           함으로써,{' '}
           <Emphasize>
-            무료 플랜에서 월 최대 30회까지(Android 빌드 기준, iOS는 최대
-            15회)밖에 안 되는
+            무료 플랜에서 iOS와 Android로 각각 15회까지밖에 안 되는
           </Emphasize>{' '}
           <Tag>eas build</Tag>의 사용 횟수를 획기적으로 줄일 수 있었습니다.
         </Paragraph>

--- a/src/shared/most-recently-edited/date.ts
+++ b/src/shared/most-recently-edited/date.ts
@@ -1,1 +1,1 @@
-export const MOST_RECENTLY_EDITED_DATE = new Date('2026-02-24');
+export const MOST_RECENTLY_EDITED_DATE = new Date('2026-02-25');

--- a/src/shared/most-recently-edited/date.ts
+++ b/src/shared/most-recently-edited/date.ts
@@ -1,1 +1,1 @@
-export const MOST_RECENTLY_EDITED_DATE = new Date('2026-02-25');
+export const MOST_RECENTLY_EDITED_DATE = new Date('2026-02-26');


### PR DESCRIPTION
- Updated `eas update`'s limit per month in the Free Plan, since the number of Android builds has decreased from 30 to 15.
  - https://expo.dev/pricing